### PR TITLE
Allow the user to specify a java version

### DIFF
--- a/ds2_configure.py
+++ b/ds2_configure.py
@@ -13,6 +13,7 @@ import sys
 import time
 import traceback
 import urllib2
+import urllib
 
 from optparse import OptionParser
 
@@ -141,6 +142,8 @@ def parse_ec2_userdata():
     parser.add_option("--opscenter", action="store", type="string", dest="opscenter")
     # Option that specifies an alternative reflector.php
     parser.add_option("--reflector", action="store", type="string", dest="reflector")
+    
+    parser.add_option("--javaversion", action="store", type="string", dest="javaversion")
 
     # Unsupported dev options
     # Option that allows for an emailed report of the startup diagnostics
@@ -177,7 +180,15 @@ def use_ec2_userdata():
 
     if options.totalnodes - options.analyticsnodes - options.searchnodes < 0:
         exit_path("Total nodes assigned > total available nodes")
-
+        
+    if options.javaversion:
+        if options.javaversion.lower() == '1.7':
+            conf.set_config("AMI", "JavaType", "1.7")
+        else:
+            conf.set_config("AMI", "JavaType", "1.6")
+    else:
+        conf.set_config("AMI", "JavaType", "1.6")
+        
     if options.version:
         if options.version.lower() == "community":
             conf.set_config("AMI", "Type", "Community")
@@ -774,8 +785,57 @@ def additional_post_configurations():
     os.chdir('/home/ubuntu')
     pass
 
+def install_java():
+    logger.info('Performing deployment install...')
+    if conf.get_config("AMI", "JavaType") == "1.7":
+        url = "http://www.java.com/en/download/manual.jsp"
+        majorversion = "7"
+    else:
+        url = "http://java.com/en/download/manual_v6.jsp"
+        majorversion = "6"
+        
+    f = urllib2.urlopen(url)
+    t = f.read()
+    
+    #regex to find java minor version
+    vr = re.compile("(?<=Update )\d+(?=.*)")
+    m = vr.search(t)
+    minorversion = m.group()
+    
+    arch = "64"
+    if arch == "64":
+        # regex to find download link
+        dlr= re.compile('(?<=Linux x64\" href=\")\S+(?=\".*)')
+    else:
+        dlr= re.compile('(?<=Linux\" href=\")\S+(?=\".*)')
+        
+    m = dlr.search(t)
+    downloadlink = m.group()
+    
+    path = "/opt/java/" + arch + "/"
+    cwd = os.curdir
+    logger.exe("sudo mkdir -p " + path);
+    os.chdir(path)
+    
+    if conf.get_config("AMI", "JavaType") == "1.7":
+        outputfilename = "jre1.7.tar.gz"
+    else:
+        outputfilename = "jre1.6.bin"
 
+    urllib.urlretrieve(downloadlink, path + outputfilename)
 
+    if conf.get_config("AMI", "JavaType") == "1.7":
+        logger.exe("sudo tar -zxvf " + path + outputfilename)
+    else:
+        logger.exe("sudo chmod +x " + path + outputfilename)
+        logger.exe("sudo " + path + outputfilename)
+
+    logger.exe('sudo update-alternatives --install "/usr/bin/java" "java" "' + path + 'jre1.' + majorversion + '.0_' + minorversion + '/bin/java" 1')
+    logger.exe('sudo update-alternatives --set "java" "' + path + 'jre1.' + majorversion + '.0_' + minorversion + '/bin/java"')
+    
+    os.chdir(cwd)
+
+        
 def run():
     # Remove script files
     logger.exe('sudo rm ds2_configure.py')
@@ -790,6 +850,7 @@ def run():
         use_ec2_userdata()
 
         confirm_authentication()
+        install_java()
         setup_repos()
         clean_installation()
         opscenter_installation()


### PR DESCRIPTION
this should allow a user to specify a java version for their ami launch

examples:
--javaversion 1.6 
--javaversion 1.7

I did attempt to build my own ami to test it. Unfortunately I could not figure out how to do it. The code does work when run own its own, but I am unsure if it works with amazon's ami launcher.
