### PR TITLE
Fix release specifying for 1.1.7 and 1.1.9

### DIFF
--- a/ds2_configure.py
+++ b/ds2_configure.py
@@ -307,8 +307,8 @@ def clean_installation():
             conf.set_config('Cassandra', 'partitioner', 'random_partitioner')
         elif options.release and options.release.startswith('1.1'):
             dse_release = cassandra_release = options.release
-            if dse_release == '1.1.6':
-                dse_release = '1.1.6-1'
+            if dse_release in ['1.1.6', '1.1.7', '1.1.9']:
+                dse_release = dse_release+'-1'
             logger.exe('sudo apt-get install -y python-cql cassandra={0} dsc1.1={1}'.format(cassandra_release, dse_release))
             conf.set_config('AMI', 'package', 'dsc1.1')
             conf.set_config('Cassandra', 'partitioner', 'random_partitioner')


### PR DESCRIPTION
Fix the community release specifying for 1.1.7 and 1.1.9, the dsc package needs "-1" just like for 1.1.6.  I think this code is write, but I changed it in the github edit interface, so should probably test it ;)
