### PR TITLE
Remove package revision number from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Community or DataStax Enterprise cluster up and running on EC2.
 Quickstart
 ==========
 
-Use `cassandralauncher` as found and documented here: 
+Use `cassandralauncher` as found and documented here:
 https://github.com/joaquincasares/cassandralauncher
 
 This will ensure all options are processed correctly and easily.
@@ -54,7 +54,7 @@ Options
 
     --release <release_version>
         Allows for the installation of a previous DSE version
-        Example: 1.0.2-1
+        Example: 1.0.2
         Default: Ignored
 
     --cfsreplicationfactor <#>


### PR DESCRIPTION
The revision number is suffixed to the install version in ds2_configure.py, so it is not needed in the release option. If someone includes the revision number in the release option, then it will break installs because it then gets included twice.
