### PR TITLE
change gpg calls to use port 80

### DIFF
--- a/ds2_configure.py
+++ b/ds2_configure.py
@@ -943,7 +943,7 @@ def sync_clocks():
     logger.exe('sudo service ntp restart')
 
 def additional_pre_configurations():
-    logger.exe('gpg --keyserver pgp.mit.edu --recv-keys 40976EAF437D05B5', expectError=True)
+    logger.exe('gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys 40976EAF437D05B5', expectError=True)
     logger.pipe('gpg --export --armor 40976EAF437D05B5', 'sudo apt-key add -')
     pass
 

--- a/presetup/pre_1.sh
+++ b/presetup/pre_1.sh
@@ -10,7 +10,7 @@ then
 fi
 
 # Download and install repo keys
-gpg --keyserver pgp.mit.edu --recv-keys 2B5C1B00
+gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys 2B5C1B00
 gpg --export --armor 2B5C1B00 | sudo apt-key add -
 wget -O - http://installer.datastax.com/downloads/ubuntuarchive.repo_key | sudo apt-key add -
 wget -O - http://debian.datastax.com/debian/repo_key | sudo apt-key add -
@@ -26,7 +26,7 @@ sudo apt-get -y install git
 git config --global color.ui auto
 git config --global color.diff auto
 git config --global color.status auto
-git clone git://github.com/riptano/ComboAMI.git datastax_ami
+git clone https://github.com/riptano/ComboAMI.git datastax_ami
 cd datastax_ami
 git checkout $(head -n 1 presetup/VERSION)
 


### PR DESCRIPTION
This change reduces the number of outbound ports that must be opened in a locked down env.
