### PR TITLE
Add VPC Cloudformation template base.

### DIFF
--- a/community_cloud/README.md
+++ b/community_cloud/README.md
@@ -9,7 +9,6 @@ Limitations
 ===========
 
 - This will not work for C* deploys that are not using vnodes.
-
 - The reflector as provided does not remember state beyond N minutes, if AWS replaces a dead node, the new node will come back in the scale group, but will not rejoin the cluster if the new node is started beyond the reflector's memory.  You will need to manually update the seed to put it back into the cluster, and also remove the dead node.
 - If you need machine types other than the m1.xlarge, you will need to add the configuration for the block mapping.
 - Your cluster (VPC) must be able to interact with sites on the internet to bootstrap the cluster.

--- a/community_cloud/README.md
+++ b/community_cloud/README.md
@@ -1,0 +1,39 @@
+Summary
+=======
+
+The template uses an AMI created with the ComboAMI scripts.
+It deploys cassandra in a scale group with the max and minimum set to the same size.  
+It uses the AWS::StackID for the custom reservation to cause a cluster in multiple AZs to connect.
+
+Limitations
+===========
+
+This will not work for C* deploys that are not using vnodes.
+
+As the reflector as provided does not remember state beyond N minutes, if AWS replaces a dead node, the new node will come back in the scale group, but will not rejoin the cluster if it happens beyond the reflector's memory.  You will need to manually update the seed to put it back into the cluster, and remove the dead node.
+
+If you need machine types other than the m1.xlarge, you will need to add the configuration for the block mapping.
+
+Your cluster must be able to interact with sites on the internet.
+
+Does not prompt for all supported parameters. Deploying the DSE will require modifying the template to support the username and password parameters.
+
+Pre-Reqs
+========
+
+You must already have your VPC configured with any security groups and connectivity configured and usable.
+
+You must edit the template file and update the mapping section providing:
+
+  -the AMI that will be used in each region
+  -your account ID
+  -the subnet-IDs
+  -availability zones
+  -security groups
+
+Quickstart
+==========
+
+Load the cloudformation template launcher, name your cluster, and select the launch template.
+
+Supply the args, use the notes from AMI to supply your needed args.

--- a/community_cloud/README.md
+++ b/community_cloud/README.md
@@ -8,15 +8,13 @@ It uses the AWS::StackID for the custom reservation to cause a cluster in multip
 Limitations
 ===========
 
-This will not work for C* deploys that are not using vnodes.
+- This will not work for C* deploys that are not using vnodes.
 
-As the reflector as provided does not remember state beyond N minutes, if AWS replaces a dead node, the new node will come back in the scale group, but will not rejoin the cluster if it happens beyond the reflector's memory.  You will need to manually update the seed to put it back into the cluster, and remove the dead node.
-
-If you need machine types other than the m1.xlarge, you will need to add the configuration for the block mapping.
-
-Your cluster must be able to interact with sites on the internet.
-
-Does not prompt for all supported parameters. Deploying the DSE will require modifying the template to support the username and password parameters.
+- The reflector as provided does not remember state beyond N minutes, if AWS replaces a dead node, the new node will come back in the scale group, but will not rejoin the cluster if the new node is started beyond the reflector's memory.  You will need to manually update the seed to put it back into the cluster, and also remove the dead node.
+- If you need machine types other than the m1.xlarge, you will need to add the configuration for the block mapping.
+- Your cluster (VPC) must be able to interact with sites on the internet to bootstrap the cluster.
+- The template does not prompt for all supported parameters. 
+- Deploying the DSE will require modifying the template to support the username and password parameters.
 
 Pre-Reqs
 ========
@@ -25,11 +23,11 @@ You must already have your VPC configured with any security groups and connectiv
 
 You must edit the template file and update the mapping section providing:
 
-  -the AMI that will be used in each region
-  -your account ID
-  -the subnet-IDs
-  -availability zones
-  -security groups
+  - the AMI that will be used in each region
+  - your account ID
+  - the subnet-IDs
+  - availability zones
+  - security groups
 
 Quickstart
 ==========

--- a/community_cloud/README.md
+++ b/community_cloud/README.md
@@ -10,7 +10,6 @@ Limitations
 
 - This will not work for C* deploys that are not using vnodes.  (DSE 4.0 and earlier does not default to use vnodes)
 - The reflector as provided does not remember state beyond N minutes, if AWS replaces a dead node, the new node will come back in the scale group, but will not rejoin the cluster if the new node is started beyond the reflector's memory.  You will need to manually update the seed to put it back into the cluster, and also remove the dead node.
-- If you need machine types other than the m1.xlarge, you will need to add the configuration for the block mapping.
 - Your cluster (VPC) must be able to interact with sites on the internet to bootstrap the cluster.
 - The template does not prompt for all supported parameters. 
 - Deploying the DSE will require modifying the template to enable it.  (It is easy to deploy a broken DSE C* with this template)

--- a/community_cloud/README.md
+++ b/community_cloud/README.md
@@ -8,13 +8,13 @@ It uses the AWS::StackID for the custom reservation to cause a cluster in multip
 Limitations
 ===========
 
-- This will not work for C* deploys that are not using vnodes.
+- This will not work for C* deploys that are not using vnodes.  (DSE 4.0 and earlier does not default to use vnodes)
 - The reflector as provided does not remember state beyond N minutes, if AWS replaces a dead node, the new node will come back in the scale group, but will not rejoin the cluster if the new node is started beyond the reflector's memory.  You will need to manually update the seed to put it back into the cluster, and also remove the dead node.
 - If you need machine types other than the m1.xlarge, you will need to add the configuration for the block mapping.
 - Your cluster (VPC) must be able to interact with sites on the internet to bootstrap the cluster.
 - The template does not prompt for all supported parameters. 
-- Deploying the DSE will require modifying the template to support the username and password parameters.
-
+- Deploying the DSE will require modifying the template to enable it.  (It is easy to deploy a broken DSE C* with this template)
+ 
 Pre-Reqs
 ========
 

--- a/community_cloud/cassandra-vpc.template
+++ b/community_cloud/cassandra-vpc.template
@@ -46,8 +46,8 @@
         "AccountName" : "(COMMENT ONLY USED TO HELP YOU WITH MULTIPLE ACCOUNT SUPPORT",
 
         "casSubnets" : ["LIST", "EACH", "SUBNET","YOU", "WANT", "TO", "USE", "BY", "subnet-ID"],
-        "casZones" : ["LIST", "EACH", "AVAILABILITY", "ZONE", "YOU", WANT", "TO", "USE", "LIKE", "us-east-1a"],
-        "casSecGroups" : ["LIST", "EACH", "SECURITY", "GROUP", "YOU", WANT", "TO", "USE", "LIKE", "sg-ID"],
+        "casZones" : ["LIST", "EACH", "AVAILABILITY", "ZONE", "YOU", "WANT", "TO", "USE", "LIKE", "us-east-1a"],
+        "casSecGroups" : ["LIST", "EACH", "SECURITY", "GROUP", "YOU", "WANT", "TO", "USE", "LIKE", "sg-ID"]
       }
     }
   },

--- a/community_cloud/cassandra-vpc.template
+++ b/community_cloud/cassandra-vpc.template
@@ -9,7 +9,7 @@
         "Default" : "Cassandra Cluster",
         "Description" : "Enter free form string for cluster name."
       },
-      "InstanceType" : {
+      "instancetype" : {
         "Type" : "String",
         "Default" : "m1.xlarge",
         "AllowedValues" : ["m1.large", "m1.xlarge"],
@@ -59,6 +59,7 @@
       "Type" : "AWS::AutoScaling::LaunchConfiguration",
       "Properties" : {
         "KeyName" : "vpc-instance",
+        "InstanceType" : { "Ref" : "instancetype" },
         "ImageId" : { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "AMI" ]},
         "SecurityGroups" : 
           { "Fn::FindInMap" : [ "AccountId", { "Ref" : "AWS::AccountId" }, "casSecGroups" ]},

--- a/community_cloud/cassandra-vpc.template
+++ b/community_cloud/cassandra-vpc.template
@@ -82,14 +82,7 @@
               ]
             ]
           }
-        },
-        "InstanceType" : "m1.xlarge",
-        "BlockDeviceMappings" : [
-          { "DeviceName" : "/dev/sdb", "VirtualName" : "ephemeral0" },
-          { "DeviceName" : "/dev/sdc", "VirtualName" : "ephemeral1" },
-          { "DeviceName" : "/dev/sdd", "VirtualName" : "ephemeral2" },
-          { "DeviceName" : "/dev/sde", "VirtualName" : "ephemeral3" }
-        ]
+        }
       }
     },
 

--- a/community_cloud/cassandra-vpc.template
+++ b/community_cloud/cassandra-vpc.template
@@ -12,8 +12,8 @@
       "InstanceType" : {
         "Type" : "String",
         "Default" : "m1.xlarge",
-        "AllowedValues" : ["m1.small", "m1.large", "m1.xlarge"],
-        "Description" : "Enter m1.small, m1.large or m1.xlarge. Default is <m1.xlarge>"
+        "AllowedValues" : ["m1.large", "m1.xlarge"],
+        "Description" : "Enter m1.large or m1.xlarge. Default is <m1.xlarge>"
       },
       "totalnodes" : {
         "Type" : "Number",
@@ -23,8 +23,8 @@
       "version" : {
         "Type" : "String",
         "Default" : "community",
-        "AllowedValues" : ["community", "enterprise"],
-        "Description" : "community or enterprise. Default is <community>"
+        "AllowedValues" : ["community"],
+        "Description" : "community only. Edit template to enable enterprise."
       },
       "reflector" : {
         "Type" : "String",
@@ -33,7 +33,6 @@
       },
       "release" : {
         "Type" : "String",
-        "Default" : "2.0.3",
         "Description" : "Release number."
       }
   },

--- a/community_cloud/cassandra-vpc.template
+++ b/community_cloud/cassandra-vpc.template
@@ -1,0 +1,110 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+
+  "Description" : "This template will launch a Cassandra Cluster in the VPC. AWS::StackId value for reflector custom reservation",
+
+  "Parameters" : {
+      "clustername" : {
+        "Type" : "String",
+        "Default" : "Cassandra Cluster",
+        "Description" : "Enter free form string for cluster name."
+      },
+      "InstanceType" : {
+        "Type" : "String",
+        "Default" : "m1.xlarge",
+        "AllowedValues" : ["m1.small", "m1.large", "m1.xlarge"],
+        "Description" : "Enter m1.small, m1.large or m1.xlarge. Default is <m1.xlarge>"
+      },
+      "totalnodes" : {
+        "Type" : "Number",
+        "Default" : "1",
+        "Description" : "Total number of cassandra nodes to deploy across all AZs."
+      },
+      "version" : {
+        "Type" : "String",
+        "Default" : "community",
+        "AllowedValues" : ["community", "enterprise"],
+        "Description" : "community or enterprise. Default is <community>"
+      },
+      "reflector" : {
+        "Type" : "String",
+        "Default" : "http://reflector2.datastax.com/reflector2.php",
+        "Description" : "reflector used during install"
+      },
+      "release" : {
+        "Type" : "String",
+        "Default" : "2.0.3",
+        "Description" : "Release number."
+      }
+  },
+
+  "Mappings" : {
+    "RegionMap" : {
+      "us-east-1"      : { "AMI" : "DEFINE EACH AMI FOR EACH REGION YOU WILL USE" }
+    },
+    "AccountId" : { 
+      "ADD_YOUR_ACCOUNT_ID_HERE" : {
+        "AccountName" : "(COMMENT ONLY USED TO HELP YOU WITH MULTIPLE ACCOUNT SUPPORT",
+
+        "casSubnets" : ["LIST", "EACH", "SUBNET","YOU", "WANT", "TO", "USE", "BY", "subnet-ID"],
+        "casZones" : ["LIST", "EACH", "AVAILABILITY", "ZONE", "YOU", WANT", "TO", "USE", "LIKE", "us-east-1a"],
+        "casSecGroups" : ["LIST", "EACH", "SECURITY", "GROUP", "YOU", WANT", "TO", "USE", "LIKE", "sg-ID"],
+      }
+    }
+  },
+
+
+  "Resources" : {
+  
+    "CassandraNode" : {
+      "Type" : "AWS::AutoScaling::LaunchConfiguration",
+      "Properties" : {
+        "KeyName" : "vpc-instance",
+        "ImageId" : { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "AMI" ]},
+        "SecurityGroups" : 
+          { "Fn::FindInMap" : [ "AccountId", { "Ref" : "AWS::AccountId" }, "casSecGroups" ]},
+        "UserData" : { 
+          "Fn::Base64" : {
+            "Fn::Join" : [ 
+              " ",
+              [
+                "--clustername",
+                { "Ref" : "clustername" },
+                "--totalnodes",
+                { "Ref" : "totalnodes" },
+                "--version",
+                { "Ref" : "version" },
+                "--release",
+                { "Ref" : "release" },
+                "--reflector",
+                { "Ref" : "reflector" },
+                "--customreservation",
+                { "Ref" : "AWS::StackId" }
+              ]
+            ]
+          }
+        },
+        "InstanceType" : "m1.xlarge",
+        "BlockDeviceMappings" : [
+          { "DeviceName" : "/dev/sdb", "VirtualName" : "ephemeral0" },
+          { "DeviceName" : "/dev/sdc", "VirtualName" : "ephemeral1" },
+          { "DeviceName" : "/dev/sdd", "VirtualName" : "ephemeral2" },
+          { "DeviceName" : "/dev/sde", "VirtualName" : "ephemeral3" }
+        ]
+      }
+    },
+
+    "CassandraPrivate" : {
+     "Type" : "AWS::AutoScaling::AutoScalingGroup",
+     "Properties" : {
+        "LaunchConfigurationName" : { "Ref" : "CassandraNode" },
+        "VPCZoneIdentifier" : { "Fn::FindInMap" : [ "AccountId", { "Ref" : "AWS::AccountId" }, "casSubnets" ]},
+        "AvailabilityZones" : { "Fn::FindInMap" : [ "AccountId", { "Ref" : "AWS::AccountId" }, "casZones" ]},
+        "MinSize" : { "Ref" : "totalnodes" },
+        "MaxSize" : { "Ref" : "totalnodes" }
+     }
+    }
+
+  }
+
+}


### PR DESCRIPTION
This is a cloudformation template and readme that can be used to launch a cluster within a VPC.  It only works in a single region.  It supports multiple availability zones.  You must edit the template and supply the required VPC networking configuration.
