### PR TITLE
Ec2MultiRegion Support

### DIFF
--- a/ds2_configure.py
+++ b/ds2_configure.py
@@ -201,7 +201,7 @@ def parse_ec2_userdata():
     # Option that forces Hadoop analytics nodes over Spark analytics nodes
     parser.add_argument("--hadoop", action="store_true", dest="hadoop")
 
-    # Option that specifies the CassandraFS replication factor
+    # Option that specifies the CassandraFS replication factor1
     parser.add_argument("--cfsreplicationfactor", action="store", type=int, dest="cfsreplication")
 
     # Option that specifies the username
@@ -281,13 +281,14 @@ def use_ec2_userdata():
     if options.customreservation:
         instance_data['reservationid'] = options.customreservation
 
-    if options.multiregion:
-        if options.seeds:
+    if options.seeds:
+        if options.multiregion:
             instance_data['seeds'] = options.seeds
         else:
             logger.warn("Ignoring seeds values because multiregion is not set to be true.")
 
-        if options.opscenterip:
+    if options.opscenterip:
+        if options.multiregion:
             instance_data['opscenterip'] = options.opscenterip
         else:
             logger.warn("Ignoring opscenterip values because multiregion is not set to be true.")
@@ -562,6 +563,8 @@ def construct_yaml():
         yaml = p.sub('rpc_address: 0.0.0.0', yaml)
 
     if options.multiregion:
+        # multiregion: --rpcbinding is implicitly true
+        yaml = p.sub('rpc_address: {0}'.format(instance_data['internalip']), yaml)
         yaml = yaml.replace('endpoint_snitch: org.apache.cassandra.locator.SimpleSnitch', 'endpoint_snitch: org.apache.cassandra.locator.Ec2MultiRegionSnitch')
         yaml = yaml.replace('endpoint_snitch: SimpleSnitch', 'endpoint_snitch: Ec2MultiRegionSnitch')
         p = re.compile('# broadcast_address: 1.2.3.4')

--- a/ds2_configure.py
+++ b/ds2_configure.py
@@ -1005,7 +1005,7 @@ def additional_pre_configurations():
     # Get required keys for Ubuntu
     logger.exe('sudo apt-key add /home/ubuntu/datastax_ami/repo_keys/Launchpad_VLC.C2518248EEA14886.key')
     logger.exe('sudo apt-key add /home/ubuntu/datastax_ami/repo_keys/Ubuntu_Archive.40976EAF437D05B5.key')
-
+    logger.exe('sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32')
 
 def additional_post_configurations():
     if options.base64postscript:

--- a/presetup/VERSION
+++ b/presetup/VERSION
@@ -1,4 +1,4 @@
-2.5
+simon
 
 DO NOT DELETE THIS FILE.
 

--- a/presetup/pre_1.sh
+++ b/presetup/pre_1.sh
@@ -24,7 +24,7 @@ sudo apt-get -y install git
 git config --global color.ui auto
 git config --global color.diff auto
 git config --global color.status auto
-git clone https://github.com/riptano/ComboAMI.git datastax_ami
+git clone https://github.com/simonso/ComboAMI.git datastax_ami
 cd datastax_ami
 git checkout $(head -n 1 presetup/VERSION)
 


### PR DESCRIPTION
# Summary

The followings are added to enable Cassandra instances launching with Ec2MultiRegion support.
# Options

```
--multiregion
  To enable multiregion support.  Values: true.
  REQUIRED
  e.g. --multiregion true --clustername t-cluster --version community --totalnodes 2

--seeds 122.33.44.55,33.44,55.66,111.222,333 
  When creating a new cluster to join an existing cluster, the public IPs of the existing cluster must be specified.
  REQUIRED (only if you are joining an existing cluster)

--opscenterip 122.33.44.55
  When creating a new cluster to join an existing cluster, the public IP of the opscenter in the existing cluster.
  REQUIRED (only if you are joining an existing cluster)

  e.g. --multiregion true --clustername t-cluster --version community --totalnodes 2 \
         --seeds 122.33.44.55,33.44,55.66,111.222,333 --opscenter 122.33.44.55

```
# Note

Sometimes it may take a few minutes for the opscenter to reflect the new datastax agents joining an existing cluster.  
