### PR TITLE
Allow customizing repository used for AMI configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ Options
         Allows you to use your own reflector
         Default: http://reflector2.datastax.com/reflector2.php
 
+    --repository <repository>:<branch>
+        Allows you to set a custom repository to pull configuration files from
+        Default: none, falls back to repository used to create the AMI
+
+    --disable-commit-verification
+        Allows you to disable latest commit verification (useful for custom repositories)
+        Default: false
+
 
 Ports Needed
 ============

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Options
         Allows you to use your own reflector
         Default: http://reflector2.datastax.com/reflector2.php
 
-    --repository <repository>:<branch>
+    --repository <repository>
         Allows you to set a custom repository to pull configuration files from
         Default: none, falls back to repository used to create the AMI
 

--- a/README.md
+++ b/README.md
@@ -83,10 +83,8 @@ Options
     --repository <repository>
         Allows you to set a custom repository to pull configuration files from
         Default: none, falls back to repository used to create the AMI
-
-    --disable-commit-verification
-        Allows you to disable latest commit verification (useful for custom repositories)
-        Default: false
+	Examples: https://github.com/riptano/ComboAMI#2.5
+	          https://github.com/riptano/ComboAMI#e5e3d41fb5f12461509aa1b6079413b381930d81
 
 
 Ports Needed

--- a/ds0_updater.py
+++ b/ds0_updater.py
@@ -5,13 +5,37 @@ import ds0_utils
 import logger
 import conf
 
+# keep it super simple for now because we don't really implement --allowed-keys yet.
+def verify_latest_commit():
+    allowed_keys = ds0_utils.allowed_keys()
+
+    # ensure the latest commit is signed and verified
+    while True:
+        for key in allowed_keys:
+            logger.exe('gpg --import ' + key['file'], expectError=True)
+        output = logger.exe('git log --pretty="format:%G?" --show-signature HEAD^..HEAD')
+
+        if "Can't check signature" in output[0]:
+            logger.info('gpg keys cleared on startup. Trying again...')
+            continue
+
+        verified = False
+        for key in allowed_keys:
+            if key['rsa_check'] in output[0] and key['signature_check'] in output[0]:
+                verified = True
+        if not verified:
+            logger.error('Scripts using a non-signed commit. Please ensure commit is valid.')
+            logger.error('    If it was a missed signature, feel free to open a ticket at https://github.com/riptano/ComboAMI.')
+        break
+
 # Update the AMI codebase if it's its first boot
 if not conf.get_config("AMI", "CompletedFirstBoot"):
     # check if a specific commit was requested
     force_commit = ds0_utils.required_commit()
 
     # update the repo
-    logger.exe('git pull')
+    repository = ds0_utils.repository()
+    logger.exe('git pull ' + repository['origin'] + ' ' + repository['branch'])
 
     # ensure any AWS removed repo keys will be put back, if removed on bake
     logger.exe('git reset --hard')
@@ -20,21 +44,10 @@ if not conf.get_config("AMI", "CompletedFirstBoot"):
     if force_commit:
         logger.exe('git reset --hard %s' % force_commit)
 
-    # ensure the latest commit is signed and verified
-    while True:
-        logger.exe('gpg --import /home/ubuntu/datastax_ami/repo_keys/DataStax_AMI.7123CDFD.key', expectError=True)
-        output = logger.exe('git log --pretty="format:%G?" --show-signature HEAD^..HEAD')
-
-        if "Can't check signature" in output[0]:
-            logger.info('gpg keys cleared on startup. Trying again...')
-            continue
-
-        rsa_check = 'using RSA key ID 7123CDFD\n'
-        signature_check = 'Good signature from "Joaquin Casares (DataStax AMI) <joaquin@datastax.com>"\n'
-        if not rsa_check in output[0] or not signature_check in output[0]:
-            logger.error('Scripts using a non-signed commit. Please ensure commit is valid.')
-            logger.error('    If it was a missed signature, feel free to open a ticket at https://github.com/riptano/ComboAMI.')
-        break
+    if ds0_utils.disable_commit_verification():
+        logger.info('Latest commit verification disabled')
+    else:
+        verify_latest_commit()
 
 # Start AMI start code
 try:

--- a/ds0_updater.py
+++ b/ds0_updater.py
@@ -34,8 +34,7 @@ if not conf.get_config("AMI", "CompletedFirstBoot"):
     force_commit = ds0_utils.required_commit()
 
     # update the repo
-    repository = ds0_utils.repository()
-    logger.exe('git pull ' + repository['origin'] + ' ' + repository['branch'])
+    logger.exe('git pull ' + ds0_utils.repository())
 
     # ensure any AWS removed repo keys will be put back, if removed on bake
     logger.exe('git reset --hard')

--- a/ds0_updater.py
+++ b/ds0_updater.py
@@ -52,7 +52,7 @@ if not conf.get_config("AMI", "CompletedFirstBoot"):
 
     # Reset the origin if a repository was specified
     if repository:
-        logger.exe('git remote remove origin')
+        logger.exe('git remote rm origin')
         logger.exe('git remote add origin %s' % repository)
 
     # update the repo

--- a/ds0_utils.py
+++ b/ds0_utils.py
@@ -63,6 +63,12 @@ def parse_ec2_userdata():
     # Development options
     # Option that specifies the cluster's name
     parser.add_argument("--forcecommit", action="store", type=str, dest="forcecommit")
+    # Option that specifies repository to use for updating
+    parser.add_argument("--repository", action="store", type=str, dest="repository")
+    # Option that specifies if to skip latest commit verification
+    parser.add_argument("--disable-commit-verification", action="store_true", dest="disablecommitverification")
+    # Option that specifies which keys are allowed to sign the latest commit (XXX not implemented)
+    parser.add_argument("--allowed-keys", action="store", nargs="+", dest="allowedkeys")
 
     try:
         (args, unknown) = parser.parse_known_args(shlex.split(instance_data['userdata']))
@@ -75,3 +81,38 @@ def required_commit():
 
     if options and options.forcecommit:
         return options.forcecommit
+
+def repository():
+    options = parse_ec2_userdata()
+
+    if options and options.repository:
+        if ':' in options.repository:
+            (origin, branch) = options.repository.split(':')
+        else:
+            origin = options.repository
+            branch = ''
+        return { 'origin': origin, 'branch': branch }
+    else:
+        return { 'origin': '', 'branch': '' }
+
+def disable_commit_verification():
+    options = parse_ec2_userdata()
+
+    if options and options.disablecommitverification:
+        return options.disablecommitverification
+    else:
+        return False
+
+def allowed_keys():
+    options = parse_ec2_userdata()
+
+    if options and options.allowedkeys:
+        return options.allowedkeys
+    else:
+        default_key = {
+            'id': '7123CDFD',
+            'file': '/home/ubuntu/datastax_ami/repo_keys/DataStax_AMI.7123CDFD.key',
+            'rsa_check': 'using RSA key ID 7123CDFD\n',
+            'signature_check': 'Good signature from "Joaquin Casares (DataStax AMI) <joaquin@datastax.com>"\n'
+        }
+        return [default_key]

--- a/ds0_utils.py
+++ b/ds0_utils.py
@@ -95,13 +95,10 @@ def repository():
 def allowed_keys():
     options = parse_ec2_userdata()
 
-    if options and options.allowedkeys:
-        return options.allowedkeys
-    else:
-        default_key = {
-            'id': '7123CDFD',
-            'file': '/home/ubuntu/datastax_ami/repo_keys/DataStax_AMI.7123CDFD.key',
-            'rsa_check': 'using RSA key ID 7123CDFD\n',
-            'signature_check': 'Good signature from "Joaquin Casares (DataStax AMI) <joaquin@datastax.com>"\n'
-        }
-        return [default_key]
+    default_key = {
+        'id': '7123CDFD',
+        'file': '/home/ubuntu/datastax_ami/repo_keys/DataStax_AMI.7123CDFD.key',
+        'rsa_check': 'using RSA key ID 7123CDFD\n',
+        'signature_check': 'Good signature from "Joaquin Casares (DataStax AMI) <joaquin@datastax.com>"\n'
+    }
+    return [default_key]

--- a/ds0_utils.py
+++ b/ds0_utils.py
@@ -61,10 +61,10 @@ def parse_ec2_userdata():
     parser = ArgumentParser()
 
     # Development options
-    # Option that specifies the cluster's name
-    parser.add_argument("--forcecommit", action="store", type=str, dest="forcecommit")
     # Option that specifies repository to use for updating
     parser.add_argument("--repository", action="store", type=str, dest="repository")
+    # Option that specifies the commit to use for updating (instead of the latest)
+    parser.add_argument("--forcecommit", action="store", type=str, dest="forcecommit")
     # Option that specifies if to skip latest commit verification
     parser.add_argument("--disable-commit-verification", action="store_true", dest="disablecommitverification")
     # Option that specifies which keys are allowed to sign the latest commit (XXX not implemented)
@@ -86,14 +86,9 @@ def repository():
     options = parse_ec2_userdata()
 
     if options and options.repository:
-        if ':' in options.repository:
-            (origin, branch) = options.repository.split(':')
-        else:
-            origin = options.repository
-            branch = ''
-        return { 'origin': origin, 'branch': branch }
+        return options.repository
     else:
-        return { 'origin': '', 'branch': '' }
+        return ''
 
 def disable_commit_verification():
     options = parse_ec2_userdata()


### PR DESCRIPTION
This is a reference pull request related to the issues raised in #72, specifically allowing a custom repository (instead of the one used to create the AMI) and allowing more than one hard-coded key for commit verification.
