### PR TITLE
Dev 2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ Options
         Allows you to download and execute a post install custom script
         Default: none
 
+    --base64postscript <base64_encoded_commands>
+        Allows you to specify a list of base64 encoded semi-colon/newline separated commands to be executed post installation
+        Default: none
+        Example: ZWNobyAtbiAiY2FzcyI7IGVjaG8gLW4gImFuZHJhIg== (echo -n "cass"; echo -n "andra")
+                 c3VkbyBhcHQtZ2V0IGluc3RhbGwgY29sbGVjdGQ= (sudo apt-get install collectd)
+
 Security Groups
 ===============
 

--- a/ds2_configure.py
+++ b/ds2_configure.py
@@ -1156,7 +1156,7 @@ def additional_pre_configurations():
 def additional_post_configurations():
     if options.base64postscript:
         command = base64.b64decode(options.base64postscript)
-        process = subprocess.Popen(shlex.split(command), stderr=subprocess.PIPE, stdout=subprocess.PIPE, shell=True)
+        process = subprocess.Popen(command, stderr=subprocess.PIPE, stdout=subprocess.PIPE, shell=True)
         read = process.communicate()
         logger.info('base64postscript response: %s\n%s' % read)
     if options.postscript_url:


### PR DESCRIPTION
In reference to #103 

Removing `shlex.split` allows for more complex post scripts to be run.

Here's an example of the change running in a python shell:

```
>>> import shlex
>>> import subprocess
>>> 
>>> command='echo -n "hello "; echo -n "world!"'
>>> 
>>> # With shlex.split
... process = subprocess.Popen(shlex.split(command), stderr=subprocess.PIPE, stdout=subprocess.PIPE, shell=True)
>>> read = process.communicate()
>>> print read
('\n', '')
>>> 
>>> # Without shlex.split
... process = subprocess.Popen(command, stderr=subprocess.PIPE, stdout=subprocess.PIPE, shell=True)
>>> read = process.communicate()
>>> print read
('hello world!', '')
```

And here's an actual deployment on EC2 using ami **DataStax Auto-Clustering AMI test-2.6.3-1404-hvm** (ami-59ff4332)

Post script:

```
echo "\n[$(date +%Y-%m-%d:%H:%M:%S)] Starting base64postscript"
echo "Post script!" > /tmp/file
cat /tmp/file
echo "[$(date +%Y-%m-%d:%H:%M:%S)] Completed base64postscript"
```

Encoded:

```
ZWNobyAiXG5bJChkYXRlICslWS0lbS0lZDolSDolTTolUyldIFN0YXJ0aW5nIGJhc2U2NHBvc3RzY3JpcHQiDQplY2hvICJQb3N0IHNjcmlwdCEiID4gL3RtcC9maWxlDQpjYXQgL3RtcC9maWxlDQplY2hvICJbJChkYXRlICslWS0lbS0lZDolSDolTTolUyldIENvbXBsZXRlZCBiYXNlNjRwb3N0c2NyaXB0Ig==
```

User-data:

```
--clustername test --totalnodes 1 --version community --repository https://github.com/AlexRudd/ComboAMI#dev-2.6 --release 2.2.3 --base64postscript ZWNobyAiXG5bJChkYXRlICslWS0lbS0lZDolSDolTTolUyldIFN0YXJ0aW5nIGJhc2U2NHBvc3RzY3JpcHQiDQplY2hvICJQb3N0IHNjcmlwdCEiID4gL3RtcC9maWxlDQpjYXQgL3RtcC9maWxlDQplY2hvICJbJChkYXRlICslWS0lbS0lZDolSDolTTolUyldIENvbXBsZXRlZCBiYXNlNjRwb3N0c2NyaXB0Ig==
```

~/datastax_ami/ami.log

```
...
[INFO] base64postscript response: 
[2015-12-01:11:41:50] Starting base64postscript
Post script!
[2015-12-01:11:41:50] Completed base64postscript
...
```
